### PR TITLE
Fix for broken behaviour in math.clamp

### DIFF
--- a/tiny-engine/src/commonMain/kotlin/com/github/minigdx/tiny/lua/MathLib.kt
+++ b/tiny-engine/src/commonMain/kotlin/com/github/minigdx/tiny/lua/MathLib.kt
@@ -49,11 +49,11 @@ class MathLib : org.luaj.vm2.lib.MathLib() {
     @TinyFunction("Clamp the value between 2 values.")
     internal inner class clamp : ThreeArgFunction() {
 
-        @TinyCall("Clamp the value between a and b.")
+        @TinyCall("Clamp the value between a and b. If a is greater than b, then b will be returned.")
         override fun call(
-            @TinyArg("a") arg1: LuaValue,
-            @TinyArg("value") arg2: LuaValue,
-            @TinyArg("b") arg3: LuaValue,
+            @TinyArg("a", "The minimum value.") arg1: LuaValue,
+            @TinyArg("value", "The value to be clamped.") arg2: LuaValue,
+            @TinyArg("b", "The maximum value.") arg3: LuaValue,
         ): LuaValue {
             val max = if (arg1.todouble() > arg2.todouble()) {
                 arg1
@@ -61,7 +61,7 @@ class MathLib : org.luaj.vm2.lib.MathLib() {
                 arg2
             }
             val min = if (max.todouble() < arg3.todouble()) {
-                arg2
+                max
             } else {
                 arg3
             }

--- a/tiny-engine/src/commonTest/kotlin/com/github/minigdx/tiny/lua/MathLibTest.kt
+++ b/tiny-engine/src/commonTest/kotlin/com/github/minigdx/tiny/lua/MathLibTest.kt
@@ -18,4 +18,16 @@ class MathLibTest {
         assertEquals(1, sign.call(valueOf(0.1)).toint())
         assertEquals(1, sign.call(valueOf("whatever")).toint())
     }
+
+    @Test
+    fun clamp() {
+        val clamp = lib.clamp()
+
+        assertEquals(0, clamp.call(valueOf(-1), valueOf(0), valueOf(1)).toint(), "Values within the given bounds should be returned as-is.")
+        assertEquals(-1, clamp.call(valueOf(-1), valueOf(-2), valueOf(1)).toint(), "The lower bound should be returned when greater than the given value.")
+        assertEquals(1, clamp.call(valueOf(-1), valueOf(2), valueOf(1)).toint(), "The upper bound should be returned when less than the given value.")
+        assertEquals(0, clamp.call(valueOf(2), valueOf(1), valueOf(0)).toint(), "The upper bound should be returned when less than the lower bound.")
+        assertEquals(1, clamp.call(valueOf(1), valueOf(0), valueOf(1)).toint(), "The upper bound should be returned when equal to the lower bound.")
+        assertEquals(0, clamp.call(valueOf("junk"), valueOf("value"), valueOf("test")).toint())
+    }
 }


### PR DESCRIPTION
There is an issue in the implementation of math.clamp, which means the value to be clamped is returned rather than the result of the check against the lower bound in all cases where b > max(a, value)

This commit fixes that behaviour, ensuring that the correct value is returned in the case of b > max(a, value)

Additionally, this commit defines the expected behaviour when a > b.

Tests included.